### PR TITLE
Add professional English documentation across libasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,179 @@
+# libasm
+
+A small x86-64 assembly library that re-implements a subset of common libc string and I/O routines for Linux, together with a C-based regression test suite.
+
+## Overview
+
+This repository builds a static library named `libasm.a` that contains NASM implementations of the following functions:
+
+- `ft_strlen`
+- `ft_strcpy`
+- `ft_strcmp`
+- `ft_write`
+- `ft_read`
+- `ft_strdup`
+
+The project is organized to make it easy to:
+
+- study how common libc behaviors map to Linux syscalls and low-level assembly,
+- compare custom assembly implementations against the standard C library,
+- validate crash behavior, return values, and `errno` propagation with automated tests.
+
+## Repository Layout
+
+- `ft_strlen.s`: Returns the length of a null-terminated string.
+- `ft_strcpy.s`: Copies a source string into a destination buffer.
+- `ft_strcmp.s`: Compares two strings byte by byte.
+- `ft_write.s`: Wraps the Linux `write` syscall and mirrors libc-style `errno` handling.
+- `ft_read.s`: Wraps the Linux `read` syscall and mirrors libc-style `errno` handling.
+- `ft_strdup.s`: Allocates and duplicates a string by reusing `ft_strlen` and `ft_strcpy`.
+- `tests/includes/tests.h`: Shared prototypes, macros, and test-suite declarations.
+- `tests/src/main.c`: Test runner entry point.
+- `tests/src/test_strlen.c`: Validation suite for `ft_strlen`.
+- `tests/src/test_strcpy.c`: Validation suite for `ft_strcpy`.
+- `tests/src/test_strcmp.c`: Validation suite for `ft_strcmp`.
+- `tests/src/test_write.c`: Validation suite for `ft_write`.
+- `tests/src/test_read.c`: Validation suite for `ft_read`.
+- `tests/src/test_strdup.c`: Validation suite for `ft_strdup`.
+
+## Requirements
+
+The build system expects the following tools to be available:
+
+- `nasm`
+- `gcc`
+- `make`
+- a Linux x86-64 environment
+
+## Build Instructions
+
+### Build the static library
+
+```bash
+make
+```
+
+This generates `libasm.a`.
+
+### Build the test executable
+
+```bash
+make test
+```
+
+This generates the test runner executable `lib_test` and links it against `libasm.a`.
+
+### Clean generated files
+
+```bash
+make clean
+```
+
+Removes intermediate object and dependency directories.
+
+### Full cleanup
+
+```bash
+make fclean
+```
+
+Removes the static library, the test executable, and generated build artifacts.
+
+### Rebuild from scratch
+
+```bash
+make re
+```
+
+Performs a full cleanup and rebuild.
+
+## Function Documentation
+
+### `size_t ft_strlen(const char *str)`
+
+Computes the number of bytes that appear before the terminating null byte in `str`.
+
+- **Input:** pointer to a null-terminated string.
+- **Return value:** string length in bytes.
+- **Important note:** this function behaves like `strlen`; passing an invalid pointer is undefined behavior.
+
+### `char *ft_strcpy(char *dest, const char *src)`
+
+Copies `src` into `dest`, including the terminating null byte.
+
+- **Input:** destination buffer and source string.
+- **Return value:** the original `dest` pointer.
+- **Important note:** `dest` must point to a buffer large enough to hold the full copied string.
+
+### `int ft_strcmp(const char *s1, const char *s2)`
+
+Compares two strings byte by byte until a difference is found or a null terminator is reached.
+
+- **Input:** two null-terminated strings.
+- **Return value:**
+  - `0` when both strings are equal,
+  - a negative value when `s1` is lexicographically smaller than `s2`,
+  - a positive value when `s1` is lexicographically greater than `s2`.
+
+### `ssize_t ft_write(int fd, const void *buf, size_t count)`
+
+Writes up to `count` bytes from `buf` to the file descriptor `fd`.
+
+- **Input:** file descriptor, buffer, and number of bytes to write.
+- **Return value:** number of bytes written, or `-1` on failure.
+- **Error handling:** when the syscall fails, the function stores the positive error code in `errno`, matching libc behavior.
+
+### `ssize_t ft_read(int fd, void *buf, size_t count)`
+
+Reads up to `count` bytes from `fd` into `buf`.
+
+- **Input:** file descriptor, destination buffer, and maximum number of bytes to read.
+- **Return value:** number of bytes read, `0` on end-of-file, or `-1` on failure.
+- **Error handling:** when the syscall fails, the function stores the positive error code in `errno`, matching libc behavior.
+
+### `char *ft_strdup(const char *s)`
+
+Allocates a new heap buffer, copies `s` into it, and returns the new pointer.
+
+- **Input:** source string.
+- **Return value:** pointer to the duplicated string, or `NULL` if memory allocation fails.
+- **Implementation detail:** the routine reuses `ft_strlen`, `malloc`, and `ft_strcpy`.
+
+## Test Suite
+
+The test program compares each assembly routine against the corresponding libc function.
+
+### Covered behaviors
+
+- standard success cases,
+- edge cases,
+- invalid descriptors,
+- `NULL` pointer crash checks where applicable,
+- pipe and file descriptor scenarios,
+- `errno` propagation,
+- repeated allocations and stress-style checks for `ft_strdup`.
+
+### Run the tests
+
+First build the executable:
+
+```bash
+make test
+```
+
+Then run it:
+
+```bash
+./lib_test
+```
+
+## Notes About the Assembly Sources
+
+The `.s` files include comments that describe:
+
+- the purpose of each routine,
+- the registers used for parameters and return values,
+- why specific registers are preserved,
+- why external calls such as `malloc`, `ft_strlen`, `ft_strcpy`, and `__errno_location` are needed.
+
+These comments are intended to make the low-level control flow easier to understand while keeping the implementation unchanged.

--- a/ft_read.s
+++ b/ft_read.s
@@ -1,5 +1,22 @@
+; -----------------------------------------------------------------------------
+; ft_read
+; -----------------------------------------------------------------------------
+; Invokes the Linux read system call and reproduces libc-style errno handling
+; on failure.
+;
+; Parameters:
+;   rdi -> File descriptor.
+;   rsi -> Destination buffer.
+;   rdx -> Maximum number of bytes to read.
+; Returns:
+;   rax -> Number of bytes read, or -1 when the syscall fails.
+; Notes:
+;   When the syscall returns a negative error code, the routine calls
+;   __errno_location to store the positive errno value before returning -1.
+; -----------------------------------------------------------------------------
 global ft_read
 extern __errno_location
+; __errno_location returns a thread-local pointer used to update errno.
 
 section .text
 	ft_read:
@@ -7,7 +24,9 @@ section .text
 		mov rbp, rsp
 		push rbx
 		push r12
+		; Preserve non-volatile registers used across the syscall and PLT call.
 
+		; Linux x86-64 syscall number 0 = read.
 		mov rax, 0
 		syscall
 
@@ -20,6 +39,7 @@ section .text
 		ret
 	
 	.error:
+		; Save the negative kernel error code before resolving errno storage.
 		mov r12, rax
 		call __errno_location wrt ..plt
 		mov rcx, r12

--- a/ft_strcmp.s
+++ b/ft_strcmp.s
@@ -1,4 +1,17 @@
-; ft_strcmp - Versión simplificada y correcta
+; -----------------------------------------------------------------------------
+; ft_strcmp
+; -----------------------------------------------------------------------------
+; Compares two null-terminated strings byte by byte using unsigned semantics.
+;
+; Parameters:
+;   rdi -> First string.
+;   rsi -> Second string.
+; Returns:
+;   eax -> Zero when strings are equal, a positive value when s1 > s2, or a
+;          negative value when s1 < s2.
+; Notes:
+;   The comparison stops at the first differing byte or at the null terminator.
+; -----------------------------------------------------------------------------
 global ft_strcmp
 
 section .text
@@ -7,6 +20,7 @@ section .text
 		mov rbp, rsp
 
 	.loop:
+		; Load and compare the current bytes from both strings.
 		mov al, [rdi]
 		cmp al, [rsi]
 		jne .diff
@@ -21,6 +35,7 @@ section .text
 		jmp .done
 
 	.diff:
+		; Re-load the bytes as unsigned values to build the exact difference.
 		movzx eax, byte [rdi]
 		movzx ecx, byte [rsi]
 		sub eax, ecx

--- a/ft_strcpy.s
+++ b/ft_strcpy.s
@@ -1,3 +1,17 @@
+; -----------------------------------------------------------------------------
+; ft_strcpy
+; -----------------------------------------------------------------------------
+; Copies a null-terminated string from src to dest, including the final
+; terminator, and returns the destination pointer.
+;
+; Parameters:
+;   rdi -> Destination buffer.
+;   rsi -> Source string.
+; Returns:
+;   rax -> Original destination pointer.
+; Notes:
+;   The destination buffer must be large enough to hold the copied string.
+; -----------------------------------------------------------------------------
 ; ft_strcpy(char *dest, const char *src)
 global ft_strcpy
 
@@ -5,6 +19,7 @@ section .text
 	ft_strcpy:
 		push rbp
 		mov rbp, rsp
+		; Keep the original destination pointer for the return value.
 		mov rax, rdi
 		xor rcx, rcx
 

--- a/ft_strdup.s
+++ b/ft_strdup.s
@@ -1,7 +1,24 @@
+; -----------------------------------------------------------------------------
+; ft_strdup
+; -----------------------------------------------------------------------------
+; Allocates a new buffer large enough to hold a copy of the input string, then
+; duplicates the contents into the new allocation.
+;
+; Parameters:
+;   rdi -> Source string to duplicate.
+; Returns:
+;   rax -> Pointer to the duplicated string, or NULL when allocation fails.
+; Notes:
+;   The implementation delegates the length calculation to ft_strlen, requests
+;   memory with malloc, and copies the bytes through ft_strcpy.
+; -----------------------------------------------------------------------------
 global ft_strdup
 extern ft_strlen
+; ft_strlen computes the number of bytes required for the source string.
 extern ft_strcpy
+; ft_strcpy copies the source bytes into the allocated destination buffer.
 extern malloc
+; malloc reserves heap memory for the duplicated string.
 
 section .text
 	ft_strdup:
@@ -9,9 +26,11 @@ section .text
 		mov rbp, rsp
 		push rbx
 
+		; Preserve the source pointer because ft_strlen consumes rdi.
 		mov rbx, rdi
 		call ft_strlen
 
+		; Reserve one extra byte for the null terminator.
 		inc rax
 
 		mov rdi, rax

--- a/ft_strlen.s
+++ b/ft_strlen.s
@@ -1,8 +1,22 @@
+; -----------------------------------------------------------------------------
+; ft_strlen
+; -----------------------------------------------------------------------------
+; Computes the length of a null-terminated string.
+;
+; Parameters:
+;   rdi -> Pointer to the input string.
+; Returns:
+;   rax -> Number of bytes before the terminating null byte.
+; Notes:
+;   This routine performs a byte-by-byte scan and mirrors the behavior of
+;   the C standard library strlen function for valid pointers.
+; -----------------------------------------------------------------------------
 ; ft_strlen(const char *str)
 global ft_strlen
 
 section .text
 	ft_strlen:
+		; Start at -1 so the first increment positions the index at byte 0.
 		mov rax, -1
 
 	.loop:

--- a/ft_write.s
+++ b/ft_write.s
@@ -1,5 +1,22 @@
+; -----------------------------------------------------------------------------
+; ft_write
+; -----------------------------------------------------------------------------
+; Invokes the Linux write system call and reproduces libc-style errno handling
+; on failure.
+;
+; Parameters:
+;   rdi -> File descriptor.
+;   rsi -> Buffer to write.
+;   rdx -> Number of bytes to write.
+; Returns:
+;   rax -> Number of bytes written, or -1 when the syscall fails.
+; Notes:
+;   When the syscall returns a negative error code, the routine calls
+;   __errno_location to store the positive errno value before returning -1.
+; -----------------------------------------------------------------------------
 global ft_write
 extern __errno_location
+; __errno_location returns a thread-local pointer used to update errno.
 
 section .text
 	ft_write:
@@ -7,7 +24,9 @@ section .text
 		mov rbp, rsp
 		push rbx
 		push r12
+		; Preserve non-volatile registers used across the syscall and PLT call.
 		
+		; Linux x86-64 syscall number 1 = write.
 		mov rax, 1
 		syscall
 		
@@ -20,6 +39,7 @@ section .text
 		ret
 		
 	.error:
+		; Save the negative kernel error code before resolving errno storage.
 		mov r12, rax
 		call __errno_location wrt ..plt
 		mov rcx, r12

--- a/tests/includes/tests.h
+++ b/tests/includes/tests.h
@@ -10,6 +10,14 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+/**
+ * @file tests.h
+ * @brief Shared declarations, color macros, and test entry points for the libasm test suite.
+ *
+ * This header exposes the assembly functions under test together with the helper
+ * callbacks and suite runners used by the C-based validation executable.
+ */
+
 #pragma once
 
 #include <stdio.h>
@@ -52,21 +60,35 @@
 
 extern sigjmp_buf env;
 
+/** Returns the number of bytes in a null-terminated string. */
 size_t	ft_strlen(const char *);
+/** Copies a null-terminated string into the destination buffer and returns dest. */
 char	*ft_strcpy(char *, const char *);
+/** Compares two strings and returns the signed byte difference at the first mismatch. */
 int		ft_strcmp(const char *, const char *);
+/** Writes up to count bytes to the given file descriptor. */
 ssize_t	ft_write(int, const void *, size_t);
+/** Reads up to count bytes from the given file descriptor into the provided buffer. */
 ssize_t ft_read(int, void *, size_t);
+/** Allocates and returns a heap-allocated duplicate of the input string. */
 char	*ft_strdup(const char *);
 
 /*  General tools   */
+/** Signal handler that turns a segmentation fault into a recoverable test event. */
 void	handle_sigsegv(int sig, siginfo_t *info, void *context);
+/** Signal handler that turns an abort into a recoverable test event. */
 void	handle_sigabrt(int sig, siginfo_t *info, void *context);
 
 /*	Test			*/
+/** Runs every strlen validation scenario. */
 void	inject_data_strlen(void);
+/** Runs every strcpy validation scenario. */
 void	inject_data_strcpy(void);
+/** Runs every strcmp validation scenario. */
 void	inject_data_strcmp(void);
+/** Runs every write validation scenario. */
 void	inject_data_write(void);
+/** Runs every read validation scenario. */
 void	inject_data_read(void);
+/** Runs every strdup validation scenario. */
 void	inject_data_strdup(void);

--- a/tests/src/main.c
+++ b/tests/src/main.c
@@ -1,5 +1,15 @@
+/**
+ * @file main.c
+ * @brief Entry point for the libasm validation executable.
+ */
+
 #include <tests.h>
 
+/**
+ * @brief Executes every test suite exposed by the repository.
+ *
+ * @return 0 after all suites have been launched.
+ */
 int	main(void)
 {
 	inject_data_strlen();

--- a/tests/src/test_read.c
+++ b/tests/src/test_read.c
@@ -1,3 +1,8 @@
+/**
+ * @file test_read.c
+ * @brief Validation scenarios for the ft_read assembly implementation.
+ */
+
 #include <tests.h>
 
 typedef struct {
@@ -23,6 +28,7 @@ typedef struct {
 		.description = desc \
 	}
 
+/** Runs a read-like function in a child process to detect crash behavior. */
 static bool check_read_crash(ssize_t (*func)(int, void *, size_t), 
 							  int fd, void *buf, size_t count)
 {
@@ -47,11 +53,13 @@ static bool check_read_crash(ssize_t (*func)(int, void *, size_t),
 	}
 }
 
+/** Resets errno before a read-oriented assertion. */
 static void clear_errno(void)
 {
 	errno = 0;
 }
 
+/** Runs one ft_read scenario and compares it against libc read. */
 static bool run_read_test(ReadTestCase *test, int index)
 {
 	dprintf(1, "\n%s--- Test %d: %s ---%s\n", CYAN, index + 1, test->name, END);
@@ -166,6 +174,7 @@ static bool run_read_test(ReadTestCase *test, int index)
 	return correct;
 }
 
+/** Covers standard-input reads that require interactive data when enabled. */
 void test_stdin_reads(void)
 {
 	dprintf(1, "\n%s--- STDIN Reads ---%s\n", CYAN, END);
@@ -192,6 +201,7 @@ void test_stdin_reads(void)
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
+/** Covers successful reads from a temporary regular file. */
 static void test_file_reads(void)
 {
 	dprintf(1, "\n%s--- File Reads ---%s\n", CYAN, END);
@@ -248,6 +258,7 @@ static void test_file_reads(void)
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
+/** Covers invalid file descriptor failures. */
 static void test_invalid_fds(void)
 {
 	dprintf(1, "\n%s--- Invalid File Descriptors ---%s\n", CYAN, END);
@@ -281,6 +292,7 @@ static void test_invalid_fds(void)
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
+/** Covers successful reads from pipe endpoints. */
 static void test_pipe_reads(void)
 {
 	dprintf(1, "\n%s--- Pipe Reads ---%s\n", CYAN, END);
@@ -288,7 +300,7 @@ static void test_pipe_reads(void)
 	int pipefd[2];
 
 	if (pipe(pipefd) == 0) {
-		// Escribir datos
+		// Write data into the pipe before exercising the read path.
 		write(pipefd[1], "Hello from pipe", 15);
 
 		// char my_buf[100] = {0};
@@ -331,6 +343,7 @@ static void test_pipe_reads(void)
 	}
 }
 
+/** Covers NULL buffers, zero counts, and large-count scenarios. */
 static void test_edge_cases(void)
 {
 	dprintf(1, "\n%s--- Edge Cases ---%s\n", CYAN, END);
@@ -386,6 +399,7 @@ static void test_edge_cases(void)
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
+/** Verifies the transition from a successful read to end-of-file. */
 static void test_eof_behavior(void)
 {
 	dprintf(1, "\n%s--- EOF Behavior ---%s\n", CYAN, END);
@@ -416,6 +430,7 @@ static void test_eof_behavior(void)
 	dprintf(1, "\n%sEOF behavior: tests completed%s\n", CYAN, END);
 }
 
+/** Verifies reads from /dev/zero. */
 static void test_dev_zero(void)
 {
 	dprintf(1, "\n%s--- Read from /dev/zero ---%s\n", CYAN, END);
@@ -431,6 +446,7 @@ static void test_dev_zero(void)
 	}
 }
 
+/** Verifies reads from /dev/urandom. */
 void test_dev_urandom(void)
 {
 	dprintf(1, "\n%s--- Read from /dev/urandom ---%s\n", CYAN, END);
@@ -446,6 +462,7 @@ void test_dev_urandom(void)
 	}
 }
 
+/** Launches the complete ft_read test suite. */
 void inject_data_read(void)
 {
 	dprintf(1, "\n%s========================================%s\n", BLUE, END);

--- a/tests/src/test_strcmp.c
+++ b/tests/src/test_strcmp.c
@@ -1,3 +1,8 @@
+/**
+ * @file test_strcmp.c
+ * @brief Validation scenarios for the ft_strcmp assembly implementation.
+ */
+
 #include <tests.h>
 
 typedef struct {
@@ -31,6 +36,7 @@ typedef struct {
 	.description = desc \
 }
 
+/** Normalizes an integer comparison result to -1, 0, or 1. */
 static int get_sign(int val) {
     if (val > 0)
 		return 1;
@@ -39,6 +45,7 @@ static int get_sign(int val) {
     return 0;
 }
 
+/** Executes a strcmp-like function while capturing crash signals for invalid input tests. */
 bool check_null(int (*func)(const char *, const char *), const char *s1, const char *s2)
 {
 	struct sigaction sa_segv, sa_abrt;
@@ -71,6 +78,7 @@ bool check_null(int (*func)(const char *, const char *), const char *s1, const c
 	return had_error;
 }
 
+/** Runs one ft_strcmp scenario and compares it against libc strcmp. */
 static bool run_strcmp_test(StrcmpTestCase *test, int index) {
 	dprintf(1, "\n%s--- Test %d: %s ---%s\n", CYAN, index + 1, test->name, END);
 	
@@ -151,6 +159,7 @@ static bool run_strcmp_test(StrcmpTestCase *test, int index) {
 	return correct;
 }
 
+/** Covers strings that should compare as equal. */
 static void test_identical_strings(void) {
 	dprintf(1, "\n%s--- Identical Strings ---%s\n", CYAN, END);
 	
@@ -192,6 +201,7 @@ static void test_identical_strings(void) {
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
+/** Covers common non-equal string comparisons. */
 static void test_different_strings(void) {
 	dprintf(1, "\n%s--- Different Strings ---%s\n", CYAN, END);
 	
@@ -234,6 +244,7 @@ static void test_different_strings(void) {
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
+/** Covers control characters, extended bytes, and UTF-8 byte sequences. */
 static void test_special_characters(void) {
 	dprintf(1, "\n%s--- Special Characters ---%s\n", CYAN, END);
 	
@@ -267,6 +278,7 @@ static void test_special_characters(void) {
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
+/** Validates exact subtraction results for representative byte pairs. */
 static void test_exact_differences(void) {
 	dprintf(1, "\n%s--- Exact Differences ---%s\n", CYAN, END);
 	
@@ -300,6 +312,7 @@ static void test_exact_differences(void) {
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
+/** Covers NULL pointers and very long strings. */
 static void test_edge_cases(void) {
 	dprintf(1, "\n%s--- Edge Cases ---%s\n", CYAN, END);
 	
@@ -371,6 +384,7 @@ static void test_edge_cases(void) {
 // 	}
 // }
 
+/** Launches the complete ft_strcmp test suite. */
 void inject_data_strcmp(void) {
     dprintf(1, "\n%s========================================%s\n", BLUE, END);
     dprintf(1, "%s         TESTING STRCMP%s\n", BLUE, END);

--- a/tests/src/test_strcpy.c
+++ b/tests/src/test_strcpy.c
@@ -1,3 +1,8 @@
+/**
+ * @file test_strcpy.c
+ * @brief Validation scenarios for the ft_strcpy assembly implementation.
+ */
+
 #include <tests.h>
 
 typedef struct {
@@ -25,6 +30,7 @@ typedef struct {
 
 static SharedResult *shared = NULL;
 
+/** Runs a strcpy-like function in a child process to detect crashes safely. */
 static bool check_aborted(char *(*func)(char *, const char *), 
 						char *dst, const char *src, 
 						char *result_buffer, size_t result_size)
@@ -72,6 +78,7 @@ static bool check_aborted(char *(*func)(char *, const char *),
 	}
 }
 
+/** Runs one buffer-copy scenario and compares ft_strcpy with libc strcpy. */
 bool run_test_case(StrcpyTestCase *test, int index) {
 	char dst_orig[test->dst_size];
 	char dst[test->dst_size];
@@ -153,6 +160,7 @@ bool run_test_case(StrcpyTestCase *test, int index) {
 	return correct;
 }
 
+/** Repeats the strcpy comparison with many source strings and a fixed buffer size. */
 void test_with_different_sources(void)
 {
 	dprintf(1, "\n%s--- Testing with different source strings ---%s\n", CYAN, END);
@@ -200,6 +208,7 @@ void test_with_different_sources(void)
 			passed, num_sources, END);
 }
 
+/** Launches the complete ft_strcpy test suite. */
 void inject_data_strcpy(void)
 {
 	dprintf(1, "\n%s========================================%s\n", BLUE, END);

--- a/tests/src/test_strdup.c
+++ b/tests/src/test_strdup.c
@@ -1,6 +1,11 @@
+/**
+ * @file test_strdup.c
+ * @brief Validation scenarios for the ft_strdup assembly implementation.
+ */
+
 #include <tests.h>
 
-// Structure for strdup test cases
+/** Describes one ft_strdup validation scenario. */
 typedef struct {
 	const char *name;
 	const char *input;
@@ -10,7 +15,7 @@ typedef struct {
 	const char *description;
 } StrdupTestCase;
 
-// Macro to create test cases
+/* Helper macro used to declare compact strdup test cases. */
 #define STRDUP_TEST_CASE(name_str, input_str, expected, err, crash, desc) \
 	{ \
 		.name = name_str, \
@@ -21,7 +26,7 @@ typedef struct {
 		.description = desc \
 	}
 
-// Helper to check if strdup crashes
+/** Runs a strdup-like function in a child process to detect crash behavior. */
 static bool check_strdup_crash(char *(*func)(const char *), const char *s)
 {
 	pid_t pid = fork();
@@ -32,7 +37,7 @@ static bool check_strdup_crash(char *(*func)(const char *), const char *s)
 	}
 	
 	if (pid == 0) {
-		// Child process
+		// Execute the function inside the isolated child process.
 		func(s);
 		_exit(0);
 	} else {
@@ -46,12 +51,13 @@ static bool check_strdup_crash(char *(*func)(const char *), const char *s)
 	}
 }
 
-// Helper to clear errno
+/** Resets errno before a strdup-oriented assertion. */
 static void clear_errno(void)
 {
 	errno = 0;
 }
 
+/** Probes whether a duplicated pointer appears readable. */
 bool is_valid_memory(char *ptr, size_t size)
 {
 	if (ptr == NULL)
@@ -62,7 +68,7 @@ bool is_valid_memory(char *ptr, size_t size)
 	return true;
 }
 
-// Run a single test case
+/** Runs one ft_strdup scenario and compares it against libc strdup. */
 static bool run_strdup_test(StrdupTestCase *test, int index)
 {
 	dprintf(1, "\n%s--- Test %d: %s ---%s\n", CYAN, index + 1, test->name, END);
@@ -111,7 +117,7 @@ static bool run_strdup_test(StrdupTestCase *test, int index)
 	
 	bool correct = true;
 	
-	// Check crash behavior
+	// Validate crash behavior.
 	if (test->should_crash) {
 		if (my_crashed != orig_crashed) {
 			dprintf(1, "  %s✗ Different crash behavior: ft=%s, orig=%s%s\n",
@@ -131,7 +137,7 @@ static bool run_strdup_test(StrdupTestCase *test, int index)
 		return correct;
 	}
 	
-	// Check errno
+	// Validate errno propagation.
 	if (my_errno_saved != orig_errno_saved) {
 		dprintf(1, "  %s✗ errno mismatch: ft=%d, orig=%d%s\n",
 				RED, my_errno_saved, orig_errno_saved, END);
@@ -143,7 +149,7 @@ static bool run_strdup_test(StrdupTestCase *test, int index)
 		correct = false;
 	}
 	
-	// Check if memory was allocated
+	// Validate that a new allocation was returned.
 	if (my_result == NULL && test->expected_result != NULL) {
 		dprintf(1, "  %s✗ ft_strdup returned NULL when expecting a string%s\n",
 				RED, END);
@@ -154,7 +160,7 @@ static bool run_strdup_test(StrdupTestCase *test, int index)
 		correct = false;
 	}
 	
-	// Compare results
+	// Compare both duplicated strings.
 	if (my_result && orig_result) {
 		if (strcmp(my_result, orig_result) != 0) {
 			dprintf(1, "  %s✗ Content mismatch: ft=\"%s\", orig=\"%s\"%s\n",
@@ -168,7 +174,7 @@ static bool run_strdup_test(StrdupTestCase *test, int index)
 			dprintf(1, "  %s✓ Content correct: \"%s\"%s\n", GREEN, my_result, END);
 		}
 		
-		// Check if memory is independent (modify one shouldn't affect the other)
+		// Verify that both returned pointers refer to independent storage.
 		if (my_result && orig_result && my_result != orig_result) {
 			char original = my_result[0];
 			if (original != '\0') {
@@ -185,7 +191,7 @@ static bool run_strdup_test(StrdupTestCase *test, int index)
 			}
 		}
 		
-		// Free allocated memory
+		// Release the heap buffers allocated during the test.
 		free(my_result);
 		free(orig_result);
 	}
@@ -199,7 +205,8 @@ static bool run_strdup_test(StrdupTestCase *test, int index)
 	return correct;
 }
 
-// Test 1: Normal strings
+// Suite 1: normal strings.
+/** Covers ordinary string duplication scenarios. */
 static void test_normal_strings(void)
 {
 	dprintf(1, "\n%s--- Normal Strings ---%s\n", CYAN, END);
@@ -245,7 +252,8 @@ static void test_normal_strings(void)
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
-// Test 2: Special characters
+// Suite 2: special characters.
+/** Covers special characters and UTF-8 payloads. */
 static void test_special_characters(void)
 {
 	dprintf(1, "\n%s--- Special Characters ---%s\n", CYAN, END);
@@ -289,7 +297,8 @@ static void test_special_characters(void)
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
-// Test 3: Edge cases
+// Suite 3: edge cases.
+/** Covers NULL pointers and very large strings. */
 static void test_edge_cases(void)
 {
 	dprintf(1, "\n%s--- Edge Cases ---%s\n", CYAN, END);
@@ -320,7 +329,8 @@ static void test_edge_cases(void)
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
-// Test 4: Memory independence test
+// Suite 4: memory independence.
+/** Verifies that the duplicate uses an independent allocation. */
 static void test_memory_independence(void)
 {
 	dprintf(1, "\n%s--- Memory Independence ---%s\n", CYAN, END);
@@ -390,7 +400,8 @@ static void test_memory_independence(void)
 	}
 }
 
-// Test 5: Multiple allocations (memory leak test)
+// Suite 5: multiple allocations.
+/** Repeats duplication across multiple independent allocations. */
 static void test_multiple_allocations(void)
 {
 	dprintf(1, "\n%s--- Multiple Allocations ---%s\n", CYAN, END);
@@ -442,7 +453,8 @@ static void test_multiple_allocations(void)
 	}
 }
 
-// Test 6: Stress test (many allocations)
+// Suite 6: stress test.
+/** Repeats allocation and free cycles to smoke-test stability. */
 static void test_stress(void)
 {
 	dprintf(1, "\n%s--- Stress Test ---%s\n", CYAN, END);
@@ -483,7 +495,8 @@ static void test_stress(void)
 	}
 }
 
-// Test 7: Very large string (memory limit test)
+// Suite 7: very large string.
+/** Duplicates a large heap-allocated string to validate scale. */
 static void test_very_large_string(void)
 {
 	dprintf(1, "\n%s--- Very Large String ---%s\n", CYAN, END);
@@ -520,7 +533,8 @@ static void test_very_large_string(void)
 	}
 }
 
-// Main test function
+// Main test entry point for this module.
+/** Launches the complete ft_strdup test suite. */
 void inject_data_strdup(void)
 {
 	dprintf(1, "\n%s========================================%s\n", BLUE, END);

--- a/tests/src/test_strlen.c
+++ b/tests/src/test_strlen.c
@@ -1,3 +1,8 @@
+/**
+ * @file test_strlen.c
+ * @brief Validation scenarios for the ft_strlen assembly implementation.
+ */
+
 #include <tests.h>
 
 sigjmp_buf env;
@@ -23,6 +28,7 @@ static const char* safe_string(const char *str) {
 	return str ? str : "NULL";
 }
 
+/** Converts SIGSEGV into a long jump so crash-oriented tests can continue. */
 void	handle_sigsegv(int sig, siginfo_t *info, void *context)
 {
 	(void)sig;
@@ -32,6 +38,7 @@ void	handle_sigsegv(int sig, siginfo_t *info, void *context)
 	siglongjmp(env, 1);
 }
 
+/** Converts SIGABRT into a long jump so abort-oriented tests can continue. */
 void handle_sigabrt(int sig, siginfo_t *info, void *context)
 {
 	(void)sig;
@@ -41,6 +48,7 @@ void handle_sigabrt(int sig, siginfo_t *info, void *context)
 	siglongjmp(env, 1);
 }
 
+/** Executes a strlen-like function while capturing crash signals for invalid input tests. */
 static bool	check_null(size_t (*func)(const char *), const char *param)
 {
 	struct sigaction sa_segv, sa_abrt;
@@ -74,6 +82,7 @@ static bool	check_null(size_t (*func)(const char *), const char *param)
 	return had_error;
 }
 
+/** Runs one ft_strlen scenario and compares the result against the libc strlen implementation. */
 static bool run_strlen_test(StrlenTestCase *test, int index) {
 	dprintf(1, "\n%s--- Test %d: %s ---%s\n", CYAN, index + 1, test->name, END);
 	
@@ -150,6 +159,7 @@ static bool run_strlen_test(StrlenTestCase *test, int index) {
 	return correct;
 }
 
+/** Covers typical ASCII strings with different lengths. */
 static void test_normal_strings(void) {
 	dprintf(1, "\n%s--- Normal Strings ---%s\n", CYAN, END);
 	
@@ -195,6 +205,7 @@ static void test_normal_strings(void) {
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
+/** Covers UTF-8 and control-character inputs handled byte by byte. */
 static void test_special_characters(void) {
 	dprintf(1, "\n%s--- Special Characters ---%s\n", CYAN, END);
 	
@@ -240,6 +251,7 @@ static void test_special_characters(void) {
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
+/** Covers NULL pointers and other edge conditions. */
 static void test_edge_cases(void) {
 	dprintf(1, "\n%s--- Edge Cases ---%s\n", CYAN, END);
 	
@@ -274,6 +286,7 @@ static void test_edge_cases(void) {
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
+/** Exercises strlen with arrays of strings to validate repeated calls. */
 static void test_string_arrays(void) {
 	dprintf(1, "\n%s--- String Arrays ---%s\n", CYAN, END);
 	
@@ -314,6 +327,7 @@ static void test_string_arrays(void) {
 			passed == num_strings ? GREEN : RED, passed, num_strings, END);
 }
 
+/** Measures ft_strlen against libc for a coarse performance comparison. */
 static void test_performance(void) {
 	dprintf(1, "\n%s--- Performance Test ---%s\n", CYAN, END);
 	
@@ -346,6 +360,7 @@ static void test_performance(void) {
 	}
 }
 
+/** Launches the complete ft_strlen test suite. */
 void inject_data_strlen(void) {
 	dprintf(1, "\n%s========================================%s\n", BLUE, END);
 	dprintf(1, "%s         TESTING STRLEN%s\n", BLUE, END);

--- a/tests/src/test_write.c
+++ b/tests/src/test_write.c
@@ -1,3 +1,8 @@
+/**
+ * @file test_write.c
+ * @brief Validation scenarios for the ft_write assembly implementation.
+ */
+
 #include <tests.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -27,6 +32,7 @@ typedef struct {
 		.description = desc \
 	}
 
+/** Runs a write-like function in a child process to detect crash behavior. */
 static bool check_write_crash(ssize_t (*func)(int, const void *, size_t), 
 							   int fd, const void *buf, size_t count)
 {
@@ -51,11 +57,13 @@ static bool check_write_crash(ssize_t (*func)(int, const void *, size_t),
 	}
 }
 
+/** Resets errno before a write-oriented assertion. */
 static void clear_errno(void)
 {
 	errno = 0;
 }
 
+/** Runs one ft_write scenario and compares it against libc write. */
 static bool run_write_test(WriteTestCase *test, int index)
 {
 	dprintf(1, "\n%s--- Test %d: %s ---%s\n", CYAN, index + 1, test->name, END);
@@ -148,6 +156,7 @@ static bool run_write_test(WriteTestCase *test, int index)
 	return correct;
 }
 
+/** Covers successful writes to standard output. */
 static void test_stdout_writes(void)
 {
 	dprintf(1, "\n%s--- STDOUT Writes ---%s\n", CYAN, END);
@@ -183,6 +192,7 @@ static void test_stdout_writes(void)
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
+/** Covers invalid file descriptor failures. */
 static void test_invalid_fds(void)
 {
 	dprintf(1, "\n%s--- Invalid File Descriptors ---%s\n", CYAN, END);
@@ -214,6 +224,7 @@ static void test_invalid_fds(void)
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
+/** Covers writes to a regular file and verifies the resulting file contents. */
 static void test_file_writes(void)
 {
 	dprintf(1, "\n%s--- File Writes ---%s\n", CYAN, END);
@@ -257,6 +268,7 @@ static void test_file_writes(void)
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
+/** Covers successful writes to standard error. */
 static void test_stderr_writes(void)
 {
 	dprintf(1, "\n%s--- STDERR Writes ---%s\n", CYAN, END);
@@ -282,6 +294,7 @@ static void test_stderr_writes(void)
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
+/** Covers NULL buffers, zero counts, and oversized counts. */
 static void test_edge_cases(void)
 {
 	dprintf(1, "\n%s--- Edge Cases ---%s\n", CYAN, END);
@@ -313,6 +326,7 @@ static void test_edge_cases(void)
 			passed == num_tests ? GREEN : RED, passed, num_tests, END);
 }
 
+/** Covers pipe writes and the broken-pipe error path. */
 static void test_pipe_writes(void)
 {
 	dprintf(1, "\n%s--- Pipe Writes ---%s\n", CYAN, END);
@@ -345,6 +359,7 @@ static void test_pipe_writes(void)
 	}
 }
 
+/** Covers EBADF behavior when writing through a read-only descriptor. */
 static void test_readonly_fd(void)
 {
 	dprintf(1, "\n%s--- Read-only File Descriptor ---%s\n", CYAN, END);
@@ -361,6 +376,7 @@ static void test_readonly_fd(void)
 	}
 }
 
+/** Launches the complete ft_write test suite. */
 void inject_data_write(void)
 {
 	dprintf(1, "\n%s========================================%s\n", BLUE, END);


### PR DESCRIPTION
### Motivation
- Improve editor hover/help experience by adding clear, English documentation for all public symbols so VS Code shows useful tooltips when hovering functions.
- Make the repository easier to read for contributors by annotating assembly routines (purpose, parameters, registers, external calls) and by documenting the test suites.
- Provide a top-level `README.md` that explains the project, build steps, functions, and how to run the tests.

### Description
- Added descriptive file-level and function-level comments to each assembly source (`ft_strlen.s`, `ft_strcpy.s`, `ft_strcmp.s`, `ft_write.s`, `ft_read.s`, `ft_strdup.s`) documenting parameters, return values, preserved registers, syscalls, and external calls.  
- Annotated the shared header `tests/includes/tests.h` with Doxygen-style comments for exported prototypes and test entry points so editor hovers show function descriptions.  
- Added English file-level and function-level comments to all test C modules under `tests/src/` (`main.c`, `test_strlen.c`, `test_strcpy.c`, `test_strcmp.c`, `test_write.c`, `test_read.c`, `test_strdup.c`) to explain their purpose and the individual test helpers.  
- Created `README.md` that describes the library, lists the implemented functions, explains build/test commands, and documents the behaviors covered by the test suite.

### Testing
- Ran the build and test workflow with `make test`, which produced `libasm.a` and the test executable; the build succeeded.  
- Executed the full test runner with `./lib_test > /tmp/libasm_test.log 2>&1`, which completed successfully and exercised all test suites.  
- Observed `SIGSEGV` warnings in the log that are expected because several crash-oriented test cases intentionally exercise invalid inputs; overall run finished without unexpected failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1652f9a40832ca8b55734be5695ef)